### PR TITLE
Fix VtM XP-purchased specialties not saving

### DIFF
--- a/src/components/character_creator/vtm/edit-vampire-5e.vue
+++ b/src/components/character_creator/vtm/edit-vampire-5e.vue
@@ -1222,7 +1222,13 @@ export default {
     },
 
     finalSpecialties() {
-      return this.kindred.specialties;
+      let specialties = [];
+      specialties = this.specialties.concat(
+        this.specialtiesFromPred,
+        this.specialtiesFromXp
+      );
+
+      return specialties;
     },
 
     saveGuard() {


### PR DESCRIPTION
## Summary
- `finalSpecialties()` in [edit-vampire-5e.vue](src/components/character_creator/vtm/edit-vampire-5e.vue) returned only `this.kindred.specialties`, dropping entries added via the Spend XP dialog (`specialtiesFromXp`) and the predator type dialog (`specialtiesFromPred`).
- Symptom: when a player spent XP on a specialty, the XP was correctly debited but the specialty never landed on the saved character — it was missing from the view page and the PDF export.
- Fix matches the working pattern already used by the VtM create flow ([vampire-5e.vue](src/components/character_creator/vtm/vampire-5e.vue)) and the werewolf/hunter edit flows: concat `specialties` with `specialtiesFromPred` and `specialtiesFromXp`.

## Test plan
- [ ] Edit an existing VtM character with XP available
- [ ] Spend XP → Specialty → pick a skill, name the specialty, Purchase, then Save in the dialog
- [ ] Save the character
- [ ] Reopen the view page and confirm the new specialty is listed
- [ ] Export PDF and confirm the specialty prints in the correct skill slot
- [ ] Sanity check: a re-save with no new specialties does not duplicate existing ones