### PR TITLE
Add docker-compose for local MySQL and DB_PORT support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: schrecknet-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "3307:3306"
+    volumes:
+      - schrecknet-mysql-data:/var/lib/mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_0900_ai_ci
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+volumes:
+  schrecknet-mysql-data:

--- a/server/database.js
+++ b/server/database.js
@@ -9,6 +9,7 @@ const sequelize = new Sequelize(
   process.env.DB_PASSWORD,
   {
     host: process.env.DB_HOST,
+    port: process.env.DB_PORT || 3306,
     dialect: "mysql",
   }
 );


### PR DESCRIPTION
## Summary
- Adds `docker-compose.yml` with a MySQL 8.0 service (`schrecknet-mysql`), a named volume `schrecknet-mysql-data` for persistence, and a healthcheck. Default host port mapping is `3307:3306` so it doesn't collide with a running Windows MySQL on 3306.
- Adds `port: process.env.DB_PORT || 3306` to the Sequelize config in `server/database.js` so the app can connect to the container on a non-default port.

## Test plan
- [ ] `docker compose up -d mysql` starts cleanly and reports healthy
- [ ] App `.env` with `DB_HOST=127.0.0.1`, `DB_PORT=3307`, valid `DB_NAME/USER/PASSWORD` connects via `npm run devStart` (Sequelize prints "Sequelize connected")
- [ ] Without `DB_PORT` set, Sequelize still defaults to 3306 (no behavior change for existing setups)