### PR TITLE
Fix XP-log undo overshoot for multi-buy advantage/flaw

### DIFF
--- a/src/components/character_creator/hunter/edit-hunter-5e.vue
+++ b/src/components/character_creator/hunter/edit-hunter-5e.vue
@@ -573,7 +573,7 @@ import edgeComponent from "./edges.vue";
 import notFound from "../../../pages/ErrorNotFound.vue";
 import hunterHandlers from "../../../lib/xp/handlers/hunter.js";
 import XpLogDialog from "../../../lib/xp/XpLogDialog.vue";
-import { appendEntry, undoLast } from "../../../lib/xp/xpLog.js";
+import { appendEntry, undoLast, isValidEntry } from "../../../lib/xp/xpLog.js";
 
 const metaData = {
   title: "SchreckNet",
@@ -1041,6 +1041,17 @@ export default {
     },
 
     onUndo(entry) {
+      // Atomic guard: skip log pop, XP refund, and handler call together if
+      // the entry is structurally invalid.  Prevents partial-undo state on a
+      // corrupted xp_log row.
+      if (!isValidEntry(entry)) {
+        this.$q.notify({
+          message: "Cannot undo this entry — log data is corrupted.",
+          color: "negative",
+          timeout: 2500,
+        });
+        return;
+      }
       const { log: next } = undoLast(this.xp_log);
       hunterHandlers[entry.type].undo(this.xpState, entry);
       this.xp += entry.cost;

--- a/src/components/character_creator/hunter/spendXp.vue
+++ b/src/components/character_creator/hunter/spendXp.vue
@@ -148,7 +148,7 @@
                 {{ this.skills[this.skillCategory.toLowerCase()] }}</q-badge
               >
 
-              <q-badge>Cost to Purchase: {{ this.calculateUpgrade() }}</q-badge>
+              <q-badge>Cost to Purchase: {{ this.displayCost() }}</q-badge>
 
               <div class="q-mt-sm" v-if="this.cost > 0">
                 <q-btn
@@ -249,6 +249,12 @@ export default defineComponent({
     };
   },
   methods: {
+    // Show "—" when the category is picked but the sub-selection isn't ready
+    // yet, avoiding "Cost to Purchase: NaN".
+    displayCost() {
+      const c = this.calculateUpgrade();
+      return Number.isFinite(c) ? c : typeof c === "string" ? c : "—";
+    },
     calculateUpgrade() {
       switch (this.categoryInput) {
         case "Advantage":

--- a/src/components/character_creator/vtm/edit-vampire-5e.vue
+++ b/src/components/character_creator/vtm/edit-vampire-5e.vue
@@ -692,7 +692,7 @@ import notFound from "../../../pages/ErrorNotFound.vue";
 import manageDisciplineFlaw from "../vtm/manageDisciplineFlaw.vue";
 import vtmHandlers from "../../../lib/xp/handlers/vtm.js";
 import XpLogDialog from "../../../lib/xp/XpLogDialog.vue";
-import { appendEntry, undoLast } from "../../../lib/xp/xpLog.js";
+import { appendEntry, undoLast, isValidEntry } from "../../../lib/xp/xpLog.js";
 
 const metaData = {
   title: "SchreckNet",
@@ -1406,6 +1406,17 @@ export default {
     },
 
     onUndo(entry) {
+      // Atomic guard: skip log pop, XP refund, and handler call together if
+      // the entry is structurally invalid.  Prevents partial-undo state on a
+      // corrupted xp_log row.
+      if (!isValidEntry(entry)) {
+        this.$q.notify({
+          message: "Cannot undo this entry — log data is corrupted.",
+          color: "negative",
+          timeout: 2500,
+        });
+        return;
+      }
       const { log: next } = undoLast(this.xp_log);
       vtmHandlers[entry.type].undo(this.xpState, entry);
       this.xp += entry.cost;

--- a/src/components/character_creator/vtm/spendXp.vue
+++ b/src/components/character_creator/vtm/spendXp.vue
@@ -200,7 +200,7 @@
                 {{ this.skills[this.skillCategory.toLowerCase()] }}</q-badge
               >
 
-              <q-badge>Cost to Purchase: {{ this.calculateUpgrade() }}</q-badge>
+              <q-badge>Cost to Purchase: {{ this.displayCost() }}</q-badge>
               <div
                 v-if="this.oblivionInput"
                 class="q-my-md"
@@ -347,6 +347,12 @@ export default defineComponent({
     };
   },
   methods: {
+    // Show "—" when the category is picked but the sub-selection (attribute,
+    // skill, discipline, etc.) isn't ready yet, avoiding "Cost to Purchase: NaN".
+    displayCost() {
+      const c = this.calculateUpgrade();
+      return Number.isFinite(c) ? c : typeof c === "string" ? c : "—";
+    },
     calculateUpgrade() {
       switch (this.categoryInput) {
         case "Advantage":
@@ -469,6 +475,10 @@ export default defineComponent({
           });
           this.localLog = appendEntry(this.localLog, partialAdv, this.localXP);
           this.advantagePoints = this.advantagePoints + this.dotsInput;
+          // Keep advantages_remaining in sync so a subsequent record() in this
+          // session captures an accurate priorValue.
+          this.advantages_remaining =
+            this.advantages_remaining + this.dotsInput;
           break;
         }
         case "Attributes": {

--- a/src/components/character_creator/werewolf/edit-garou-5e.vue
+++ b/src/components/character_creator/werewolf/edit-garou-5e.vue
@@ -607,7 +607,7 @@ import tribeComponent from "../werewolf/tribes.vue";
 import nosImage from "../../../assets/images/Nosfer_logo.png";
 import werewolfHandlers from "../../../lib/xp/handlers/werewolf.js";
 import XpLogDialog from "../../../lib/xp/XpLogDialog.vue";
-import { appendEntry, undoLast } from "../../../lib/xp/xpLog.js";
+import { appendEntry, undoLast, isValidEntry } from "../../../lib/xp/xpLog.js";
 
 const metaData = {
   title: "SchreckNet",
@@ -1067,6 +1067,17 @@ export default {
     },
 
     onUndo(entry) {
+      // Atomic guard: skip log pop, XP refund, and handler call together if
+      // the entry is structurally invalid.  Prevents partial-undo state on a
+      // corrupted xp_log row.
+      if (!isValidEntry(entry)) {
+        this.$q.notify({
+          message: "Cannot undo this entry — log data is corrupted.",
+          color: "negative",
+          timeout: 2500,
+        });
+        return;
+      }
       const { log: next } = undoLast(this.xp_log);
       werewolfHandlers[entry.type].undo(this.xpState, entry);
       this.xp += entry.cost;

--- a/src/components/character_creator/werewolf/spendXp.vue
+++ b/src/components/character_creator/werewolf/spendXp.vue
@@ -206,7 +206,7 @@
                 }}</q-badge
               >
 
-              <q-badge>Cost to Purchase: {{ this.calculateUpgrade() }}</q-badge>
+              <q-badge>Cost to Purchase: {{ this.displayCost() }}</q-badge>
 
               <div class="q-mt-sm" v-if="this.cost > 0">
                 <q-btn
@@ -429,6 +429,12 @@ export default defineComponent({
       }
     },
 
+    // Show "—" when the category is picked but the sub-selection isn't ready
+    // yet, avoiding "Cost to Purchase: NaN".
+    displayCost() {
+      const c = this.calculateUpgrade();
+      return Number.isFinite(c) ? c : typeof c === "string" ? c : "—";
+    },
     calculateUpgrade() {
       switch (this.categoryInput) {
         case "Advantage":

--- a/src/lib/xp/XpLogDialog.vue
+++ b/src/lib/xp/XpLogDialog.vue
@@ -132,14 +132,19 @@ export default {
     },
     confirmUndo(entry) {
       const label = this.labelFor(entry);
-      const tail =
+      const xpTail =
         entry.cost >= 0
           ? `you'll get ${entry.cost} XP back`
           : `you'll re-spend ${-entry.cost} XP`;
+      const handler = this.handlers[entry.type];
+      const effect = handler?.undoEffect ? handler.undoEffect(entry) : null;
+      const message = effect
+        ? `${label} — ${xpTail}, and ${effect}.`
+        : `${label} — ${xpTail}.`;
       this.$q
         .dialog({
           title: "Undo this purchase?",
-          message: `${label} — ${tail}.`,
+          message,
           ok: { label: "Undo", color: "secondary", unelevated: true },
           cancel: { flat: true, color: "white" },
           persistent: true,

--- a/src/lib/xp/__tests__/xpLog.test.js
+++ b/src/lib/xp/__tests__/xpLog.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { appendEntry, undoLast, newId } from "../xpLog.js";
+import { appendEntry, undoLast, newId, isValidEntry } from "../xpLog.js";
 
 describe("newId", () => {
   it("returns a distinct string each call", () => {
@@ -40,6 +40,90 @@ describe("appendEntry", () => {
   it("preserves provided note if any", () => {
     const result = appendEntry([], { cost: 1, type: "x", payload: {}, note: "hello" }, 5);
     expect(result[0].note).toBe("hello");
+  });
+});
+
+describe("isValidEntry", () => {
+  it("accepts a well-formed entry with finite cost", () => {
+    expect(
+      isValidEntry({ type: "attribute_raise", cost: 15, payload: {} })
+    ).toBe(true);
+  });
+
+  it("accepts an advantage entry with finite cost and delta", () => {
+    expect(
+      isValidEntry({
+        type: "advantage",
+        cost: 6,
+        payload: { counter: "advantages_remaining", priorValue: 0, delta: 2 },
+      })
+    ).toBe(true);
+  });
+
+  it("accepts a flaw entry with finite cost and delta", () => {
+    expect(
+      isValidEntry({
+        type: "flaw",
+        cost: 3,
+        payload: { counter: "flaws_remaining", priorValue: 0, delta: 1 },
+      })
+    ).toBe(true);
+  });
+
+  it("rejects null / undefined / non-object", () => {
+    expect(isValidEntry(null)).toBe(false);
+    expect(isValidEntry(undefined)).toBe(false);
+    expect(isValidEntry(42)).toBe(false);
+    expect(isValidEntry("entry")).toBe(false);
+  });
+
+  it("rejects when cost is non-finite (NaN, Infinity, string)", () => {
+    expect(
+      isValidEntry({ type: "attribute_raise", cost: NaN, payload: {} })
+    ).toBe(false);
+    expect(
+      isValidEntry({ type: "attribute_raise", cost: Infinity, payload: {} })
+    ).toBe(false);
+    expect(
+      isValidEntry({ type: "attribute_raise", cost: "junk", payload: {} })
+    ).toBe(false);
+    expect(
+      isValidEntry({ type: "attribute_raise", payload: {} })
+    ).toBe(false); // missing cost
+  });
+
+  it("rejects advantage/flaw with non-finite delta", () => {
+    expect(
+      isValidEntry({
+        type: "advantage",
+        cost: 6,
+        payload: { counter: "advantages_remaining", delta: NaN },
+      })
+    ).toBe(false);
+    expect(
+      isValidEntry({
+        type: "flaw",
+        cost: 3,
+        payload: { counter: "flaws_remaining", delta: "junk" },
+      })
+    ).toBe(false);
+    expect(
+      isValidEntry({
+        type: "advantage",
+        cost: 6,
+        payload: { counter: "advantages_remaining" }, // missing delta
+      })
+    ).toBe(false);
+  });
+
+  it("does not require delta on non-advantage/flaw entries", () => {
+    expect(
+      isValidEntry({
+        type: "skill_raise",
+        cost: 3,
+        payload: { skill: "brawl" }, // no delta — fine
+      })
+    ).toBe(true);
   });
 });
 

--- a/src/lib/xp/handlers/__tests__/hunter.test.js
+++ b/src/lib/xp/handlers/__tests__/hunter.test.js
@@ -279,6 +279,51 @@ describe("hunter handlers — record/undo round trip", () => {
     expect(charState.spentXp).toBe(3);
   });
 
+  // ── delta validation ────────────────────────────────────────────────────
+  it("advantage undo: non-finite delta is silently ignored", () => {
+    const charState = { advantagePoints: 4, spentXp: 12 };
+    handlers.advantage.undo(charState, {
+      type: "advantage",
+      cost: 0,
+      payload: {
+        counter: "advantagePoints",
+        priorValue: 0,
+        delta: NaN,
+        priorSpentXp: 0,
+      },
+    });
+    expect(charState.advantagePoints).toBe(4);
+    expect(charState.spentXp).toBe(12);
+  });
+
+  it("flaw undo: non-finite delta is silently ignored", () => {
+    const charState = { flaws_remaining: 2, spentXp: 6 };
+    handlers.flaw.undo(charState, {
+      type: "flaw",
+      cost: 0,
+      payload: {
+        counter: "flaws_remaining",
+        priorValue: 0,
+        delta: "junk",
+        priorSpentXp: 0,
+      },
+    });
+    expect(charState.flaws_remaining).toBe(2);
+    expect(charState.spentXp).toBe(6);
+  });
+
+  it("advantage undoEffect: describes the dot reversal", () => {
+    expect(
+      handlers.advantage.undoEffect({ payload: { delta: 3 } })
+    ).toBe("3 advantage dot(s) will be removed");
+  });
+
+  it("flaw undoEffect: describes the dot reversal", () => {
+    expect(
+      handlers.flaw.undoEffect({ payload: { delta: 1 } })
+    ).toBe("1 flaw dot(s) will be removed");
+  });
+
   // ── allowlist guards ────────────────────────────────────────────────────
   it("advantage undo: malicious counter key is silently ignored", () => {
     const charState = { advantagePoints: 3, spentXp: 6 };

--- a/src/lib/xp/handlers/__tests__/hunter.test.js
+++ b/src/lib/xp/handlers/__tests__/hunter.test.js
@@ -234,6 +234,51 @@ describe("hunter handlers — record/undo round trip", () => {
     expect(charState.spentXp).toBe(0);
   });
 
+  // ── multi-record dialog session ─────────────────────────────────────────
+  // The undo math should be robust against stale priorValue — reversing only
+  // this entry's delta — regardless of dialog mutation order.
+  it("advantage multi-record (stale priorValue): undoing the top entry only reverses its own delta", () => {
+    const charState = { advantagePoints: 2, spentXp: 6 };
+    const e1 = handlers.advantage.record(charState, { delta: 2 });
+    charState.spentXp = 12;
+    const e2 = handlers.advantage.record(charState, { delta: 3 });
+    expect(e1.payload.priorValue).toBe(2);
+    expect(e2.payload.priorValue).toBe(2);
+    expect(e1.payload.priorSpentXp).toBe(6);
+    expect(e2.payload.priorSpentXp).toBe(12);
+
+    charState.advantagePoints = 7;
+    charState.spentXp = 21;
+
+    handlers.advantage.undo(charState, e2);
+    expect(charState.advantagePoints).toBe(4);
+    expect(charState.spentXp).toBe(12);
+    handlers.advantage.undo(charState, e1);
+    expect(charState.advantagePoints).toBe(2);
+    expect(charState.spentXp).toBe(6);
+  });
+
+  it("flaw multi-record (stale priorValue): undoing the top entry only reverses its own delta", () => {
+    const charState = { flaws_remaining: 1, spentXp: 3 };
+    const e1 = handlers.flaw.record(charState, { delta: 1 });
+    charState.spentXp = 6;
+    const e2 = handlers.flaw.record(charState, { delta: 2 });
+    expect(e1.payload.priorValue).toBe(1);
+    expect(e2.payload.priorValue).toBe(1);
+    expect(e1.payload.priorSpentXp).toBe(3);
+    expect(e2.payload.priorSpentXp).toBe(6);
+
+    charState.flaws_remaining = 4;
+    charState.spentXp = 12;
+
+    handlers.flaw.undo(charState, e2);
+    expect(charState.flaws_remaining).toBe(2);
+    expect(charState.spentXp).toBe(6);
+    handlers.flaw.undo(charState, e1);
+    expect(charState.flaws_remaining).toBe(1);
+    expect(charState.spentXp).toBe(3);
+  });
+
   // ── allowlist guards ────────────────────────────────────────────────────
   it("advantage undo: malicious counter key is silently ignored", () => {
     const charState = { advantagePoints: 3, spentXp: 6 };

--- a/src/lib/xp/handlers/__tests__/vtm.test.js
+++ b/src/lib/xp/handlers/__tests__/vtm.test.js
@@ -386,6 +386,56 @@ describe("vtm handlers — record/undo round trip", () => {
     expect(charState.flaws_remaining).toBe(2);
   });
 
+  it("advantage undo: non-finite delta (NaN, Infinity) is silently ignored", () => {
+    const charState = { advantages_remaining: 5 };
+    handlers.advantage.undo(charState, {
+      type: "advantage",
+      cost: 0,
+      payload: { counter: "advantages_remaining", priorValue: 0, delta: NaN },
+    });
+    expect(charState.advantages_remaining).toBe(5);
+    handlers.advantage.undo(charState, {
+      type: "advantage",
+      cost: 0,
+      payload: { counter: "advantages_remaining", priorValue: 0, delta: Infinity },
+    });
+    expect(charState.advantages_remaining).toBe(5);
+    handlers.advantage.undo(charState, {
+      type: "advantage",
+      cost: 0,
+      payload: { counter: "advantages_remaining", priorValue: 0, delta: "junk" },
+    });
+    expect(charState.advantages_remaining).toBe(5);
+  });
+
+  it("flaw undo: non-finite delta is silently ignored", () => {
+    const charState = { flaws_remaining: 3 };
+    handlers.flaw.undo(charState, {
+      type: "flaw",
+      cost: 0,
+      payload: { counter: "flaws_remaining", priorValue: 0, delta: NaN },
+    });
+    expect(charState.flaws_remaining).toBe(3);
+  });
+
+  it("advantage undoEffect: describes the dot reversal", () => {
+    expect(
+      handlers.advantage.undoEffect({ payload: { delta: 3 } })
+    ).toBe("3 advantage dot(s) will be removed");
+    expect(
+      handlers.advantage.undoEffect({ payload: { delta: -2 } })
+    ).toBe("2 advantage dot(s) will be restored");
+  });
+
+  it("flaw undoEffect: describes the dot reversal", () => {
+    expect(
+      handlers.flaw.undoEffect({ payload: { delta: 1 } })
+    ).toBe("1 flaw dot(s) will be removed");
+    expect(
+      handlers.flaw.undoEffect({ payload: { delta: -2 } })
+    ).toBe("2 flaw dot(s) will be restored");
+  });
+
   it("advantage undo: malicious counter key is silently ignored", () => {
     const charState = { advantages_remaining: 5 };
     const maliciousEntry = {

--- a/src/lib/xp/handlers/__tests__/vtm.test.js
+++ b/src/lib/xp/handlers/__tests__/vtm.test.js
@@ -348,6 +348,44 @@ describe("vtm handlers — record/undo round trip", () => {
     expect(charState.flaws_remaining).toBe(4);
   });
 
+  it("advantage multi-record (stale priorValue): undoing the top entry only reverses its own delta", () => {
+    // Reproduces the spendXp dialog session bug: two record() calls inside one
+    // dialog read the same advantages_remaining (the dialog never mutates it
+    // between record calls), so both entries share priorValue.  The undo for
+    // the top entry must reverse only its own delta — not snap state back to
+    // the shared priorValue.
+    const charState = { advantages_remaining: 5 };
+    const e1 = handlers.advantage.record(charState, { delta: 2 });
+    const e2 = handlers.advantage.record(charState, { delta: 3 });
+    // Both entries captured the same priorValue (the dialog bug):
+    expect(e1.payload.priorValue).toBe(5);
+    expect(e2.payload.priorValue).toBe(5);
+
+    // Parent applied both purchases: 5 + 2 + 3 = 10
+    charState.advantages_remaining = 10;
+
+    handlers.advantage.undo(charState, e2);
+    expect(charState.advantages_remaining).toBe(7);
+    handlers.advantage.undo(charState, e1);
+    expect(charState.advantages_remaining).toBe(5);
+  });
+
+  it("flaw multi-record (stale priorValue): undoing the top entry only reverses its own delta", () => {
+    const charState = { flaws_remaining: 2 };
+    const e1 = handlers.flaw.record(charState, { delta: 1 });
+    const e2 = handlers.flaw.record(charState, { delta: 2 });
+    expect(e1.payload.priorValue).toBe(2);
+    expect(e2.payload.priorValue).toBe(2);
+
+    // Parent applied both: 2 + 1 + 2 = 5
+    charState.flaws_remaining = 5;
+
+    handlers.flaw.undo(charState, e2);
+    expect(charState.flaws_remaining).toBe(3);
+    handlers.flaw.undo(charState, e1);
+    expect(charState.flaws_remaining).toBe(2);
+  });
+
   it("advantage undo: malicious counter key is silently ignored", () => {
     const charState = { advantages_remaining: 5 };
     const maliciousEntry = {

--- a/src/lib/xp/handlers/__tests__/werewolf.test.js
+++ b/src/lib/xp/handlers/__tests__/werewolf.test.js
@@ -370,6 +370,51 @@ describe("werewolf handlers — record/undo round trip", () => {
     expect(charState.spent_xp).toBe(3);
   });
 
+  // ── delta validation ────────────────────────────────────────────────────
+  it("advantage undo: non-finite delta is silently ignored", () => {
+    const charState = { advantagePoints: 4, spent_xp: 12 };
+    handlers.advantage.undo(charState, {
+      type: "advantage",
+      cost: 0,
+      payload: {
+        counter: "advantagePoints",
+        priorValue: 0,
+        delta: NaN,
+        priorSpentXp: 0,
+      },
+    });
+    expect(charState.advantagePoints).toBe(4);
+    expect(charState.spent_xp).toBe(12);
+  });
+
+  it("flaw undo: non-finite delta is silently ignored", () => {
+    const charState = { flaws_remaining: 2, spent_xp: 6 };
+    handlers.flaw.undo(charState, {
+      type: "flaw",
+      cost: 0,
+      payload: {
+        counter: "flaws_remaining",
+        priorValue: 0,
+        delta: Infinity,
+        priorSpentXp: 0,
+      },
+    });
+    expect(charState.flaws_remaining).toBe(2);
+    expect(charState.spent_xp).toBe(6);
+  });
+
+  it("advantage undoEffect: describes the dot reversal", () => {
+    expect(
+      handlers.advantage.undoEffect({ payload: { delta: 2 } })
+    ).toBe("2 advantage dot(s) will be removed");
+  });
+
+  it("flaw undoEffect: describes the dot reversal", () => {
+    expect(
+      handlers.flaw.undoEffect({ payload: { delta: 1 } })
+    ).toBe("1 flaw dot(s) will be removed");
+  });
+
   // ── allowlist guards ────────────────────────────────────────────────────
   it("advantage undo: malicious counter key is silently ignored", () => {
     const charState = { advantagePoints: 3, spent_xp: 6 };

--- a/src/lib/xp/handlers/__tests__/werewolf.test.js
+++ b/src/lib/xp/handlers/__tests__/werewolf.test.js
@@ -321,6 +321,55 @@ describe("werewolf handlers — record/undo round trip", () => {
     expect(charState.spent_xp).toBe(0);
   });
 
+  // ── multi-record dialog session ─────────────────────────────────────────
+  // The undo math should be robust against stale priorValue — i.e., reversing
+  // only this entry's delta — regardless of whether the dialog updated the
+  // counter between record calls.  Simulates a dialog session that updates
+  // spent_xp between calls (priorSpentXp progresses normally) but does NOT
+  // update the counter (priorValue stays at the dialog-open snapshot).
+  it("advantage multi-record (stale priorValue): undoing the top entry only reverses its own delta", () => {
+    const charState = { advantagePoints: 2, spent_xp: 6 };
+    const e1 = handlers.advantage.record(charState, { delta: 2 });
+    charState.spent_xp = 12; // dialog: localSpentXp += cost (6)
+    const e2 = handlers.advantage.record(charState, { delta: 3 });
+    expect(e1.payload.priorValue).toBe(2);
+    expect(e2.payload.priorValue).toBe(2); // stale — counter wasn't updated
+    expect(e1.payload.priorSpentXp).toBe(6);
+    expect(e2.payload.priorSpentXp).toBe(12); // progressed correctly
+
+    // Parent applied both purchases: advantagePoints 2 + 2 + 3 = 7, spent_xp 12 + 9 = 21
+    charState.advantagePoints = 7;
+    charState.spent_xp = 21;
+
+    handlers.advantage.undo(charState, e2);
+    expect(charState.advantagePoints).toBe(4);
+    expect(charState.spent_xp).toBe(12);
+    handlers.advantage.undo(charState, e1);
+    expect(charState.advantagePoints).toBe(2);
+    expect(charState.spent_xp).toBe(6);
+  });
+
+  it("flaw multi-record (stale priorValue): undoing the top entry only reverses its own delta", () => {
+    const charState = { flaws_remaining: 1, spent_xp: 3 };
+    const e1 = handlers.flaw.record(charState, { delta: 1 });
+    charState.spent_xp = 6; // dialog: localSpentXp += cost (3)
+    const e2 = handlers.flaw.record(charState, { delta: 2 });
+    expect(e1.payload.priorValue).toBe(1);
+    expect(e2.payload.priorValue).toBe(1);
+    expect(e1.payload.priorSpentXp).toBe(3);
+    expect(e2.payload.priorSpentXp).toBe(6);
+
+    charState.flaws_remaining = 4;
+    charState.spent_xp = 12;
+
+    handlers.flaw.undo(charState, e2);
+    expect(charState.flaws_remaining).toBe(2);
+    expect(charState.spent_xp).toBe(6);
+    handlers.flaw.undo(charState, e1);
+    expect(charState.flaws_remaining).toBe(1);
+    expect(charState.spent_xp).toBe(3);
+  });
+
   // ── allowlist guards ────────────────────────────────────────────────────
   it("advantage undo: malicious counter key is silently ignored", () => {
     const charState = { advantagePoints: 3, spent_xp: 6 };

--- a/src/lib/xp/handlers/hunter.js
+++ b/src/lib/xp/handlers/hunter.js
@@ -148,9 +148,12 @@ const handlers = {
         },
       };
     },
+    // Reverse the counter by delta — robust against stale priorValue from old
+    // log entries.  spentXp is restored from priorSpentXp because the dialog
+    // mutates localSpentXp between record calls.
     undo: (state, entry) => {
       if (!ADVANTAGE_FLAW_COUNTERS.has(entry.payload.counter)) return;
-      state[entry.payload.counter] = entry.payload.priorValue;
+      state[entry.payload.counter] -= entry.payload.delta;
       state.spentXp = entry.payload.priorSpentXp;
     },
   },
@@ -177,7 +180,7 @@ const handlers = {
     },
     undo: (state, entry) => {
       if (!ADVANTAGE_FLAW_COUNTERS.has(entry.payload.counter)) return;
-      state[entry.payload.counter] = entry.payload.priorValue;
+      state[entry.payload.counter] -= entry.payload.delta;
       state.spentXp = entry.payload.priorSpentXp;
     },
   },

--- a/src/lib/xp/handlers/hunter.js
+++ b/src/lib/xp/handlers/hunter.js
@@ -134,6 +134,10 @@ const handlers = {
       e.payload.delta > 0
         ? `Added ${e.payload.delta} advantage point(s)`
         : `Removed ${Math.abs(e.payload.delta)} advantage point(s)`,
+    undoEffect: (e) =>
+      e.payload.delta > 0
+        ? `${e.payload.delta} advantage dot(s) will be removed`
+        : `${Math.abs(e.payload.delta)} advantage dot(s) will be restored`,
     record: (state, input) => {
       const counter = "advantagePoints";
       const priorValue = state[counter];
@@ -153,7 +157,9 @@ const handlers = {
     // mutates localSpentXp between record calls.
     undo: (state, entry) => {
       if (!ADVANTAGE_FLAW_COUNTERS.has(entry.payload.counter)) return;
-      state[entry.payload.counter] -= entry.payload.delta;
+      const delta = Number(entry.payload.delta);
+      if (!Number.isFinite(delta)) return;
+      state[entry.payload.counter] -= delta;
       state.spentXp = entry.payload.priorSpentXp;
     },
   },
@@ -164,6 +170,10 @@ const handlers = {
       e.payload.delta > 0
         ? `Added ${e.payload.delta} flaw point(s)`
         : `Removed ${Math.abs(e.payload.delta)} flaw point(s)`,
+    undoEffect: (e) =>
+      e.payload.delta > 0
+        ? `${e.payload.delta} flaw dot(s) will be removed`
+        : `${Math.abs(e.payload.delta)} flaw dot(s) will be restored`,
     record: (state, input) => {
       const counter = "flaws_remaining";
       const priorValue = state[counter];
@@ -180,7 +190,9 @@ const handlers = {
     },
     undo: (state, entry) => {
       if (!ADVANTAGE_FLAW_COUNTERS.has(entry.payload.counter)) return;
-      state[entry.payload.counter] -= entry.payload.delta;
+      const delta = Number(entry.payload.delta);
+      if (!Number.isFinite(delta)) return;
+      state[entry.payload.counter] -= delta;
       state.spentXp = entry.payload.priorSpentXp;
     },
   },

--- a/src/lib/xp/handlers/vtm.js
+++ b/src/lib/xp/handlers/vtm.js
@@ -214,6 +214,10 @@ const handlers = {
       e.payload.delta > 0
         ? `Added ${e.payload.delta} advantage point(s)`
         : `Removed ${Math.abs(e.payload.delta)} advantage point(s)`,
+    undoEffect: (e) =>
+      e.payload.delta > 0
+        ? `${e.payload.delta} advantage dot(s) will be removed`
+        : `${Math.abs(e.payload.delta)} advantage dot(s) will be restored`,
     record: (state, input) => {
       const counter = "advantages_remaining";
       const priorValue = state[counter];
@@ -228,7 +232,9 @@ const handlers = {
     // between record calls.
     undo: (state, entry) => {
       if (!ADVANTAGE_FLAW_COUNTERS.has(entry.payload.counter)) return;
-      state[entry.payload.counter] -= entry.payload.delta;
+      const delta = Number(entry.payload.delta);
+      if (!Number.isFinite(delta)) return;
+      state[entry.payload.counter] -= delta;
     },
   },
 
@@ -237,6 +243,10 @@ const handlers = {
       e.payload.delta > 0
         ? `Added ${e.payload.delta} flaw point(s)`
         : `Removed ${Math.abs(e.payload.delta)} flaw point(s)`,
+    undoEffect: (e) =>
+      e.payload.delta > 0
+        ? `${e.payload.delta} flaw dot(s) will be removed`
+        : `${Math.abs(e.payload.delta)} flaw dot(s) will be restored`,
     record: (state, input) => {
       const counter = "flaws_remaining";
       const priorValue = state[counter];
@@ -248,7 +258,9 @@ const handlers = {
     },
     undo: (state, entry) => {
       if (!ADVANTAGE_FLAW_COUNTERS.has(entry.payload.counter)) return;
-      state[entry.payload.counter] -= entry.payload.delta;
+      const delta = Number(entry.payload.delta);
+      if (!Number.isFinite(delta)) return;
+      state[entry.payload.counter] -= delta;
     },
   },
 };

--- a/src/lib/xp/handlers/vtm.js
+++ b/src/lib/xp/handlers/vtm.js
@@ -223,9 +223,12 @@ const handlers = {
         payload: { counter, priorValue, delta: input.delta },
       };
     },
+    // Reverse by delta — robust against stale priorValue from log entries
+    // recorded before the spendXp dialog was fixed to mutate the counter
+    // between record calls.
     undo: (state, entry) => {
       if (!ADVANTAGE_FLAW_COUNTERS.has(entry.payload.counter)) return;
-      state[entry.payload.counter] = entry.payload.priorValue;
+      state[entry.payload.counter] -= entry.payload.delta;
     },
   },
 
@@ -245,7 +248,7 @@ const handlers = {
     },
     undo: (state, entry) => {
       if (!ADVANTAGE_FLAW_COUNTERS.has(entry.payload.counter)) return;
-      state[entry.payload.counter] = entry.payload.priorValue;
+      state[entry.payload.counter] -= entry.payload.delta;
     },
   },
 };

--- a/src/lib/xp/handlers/werewolf.js
+++ b/src/lib/xp/handlers/werewolf.js
@@ -226,9 +226,13 @@ const handlers = {
         },
       };
     },
+    // Reverse the counter by delta — robust against stale priorValue from old
+    // log entries.  spent_xp is restored from priorSpentXp because the dialog
+    // mutates localSpentXp between record calls (each entry's priorSpentXp
+    // reflects the state just before that purchase).
     undo: (state, entry) => {
       if (!ADVANTAGE_FLAW_COUNTERS.has(entry.payload.counter)) return;
-      state[entry.payload.counter] = entry.payload.priorValue;
+      state[entry.payload.counter] -= entry.payload.delta;
       state.spent_xp = entry.payload.priorSpentXp;
     },
   },
@@ -254,7 +258,7 @@ const handlers = {
     },
     undo: (state, entry) => {
       if (!ADVANTAGE_FLAW_COUNTERS.has(entry.payload.counter)) return;
-      state[entry.payload.counter] = entry.payload.priorValue;
+      state[entry.payload.counter] -= entry.payload.delta;
       state.spent_xp = entry.payload.priorSpentXp;
     },
   },

--- a/src/lib/xp/handlers/werewolf.js
+++ b/src/lib/xp/handlers/werewolf.js
@@ -212,6 +212,10 @@ const handlers = {
       e.payload.delta > 0
         ? `Added ${e.payload.delta} advantage point(s)`
         : `Removed ${Math.abs(e.payload.delta)} advantage point(s)`,
+    undoEffect: (e) =>
+      e.payload.delta > 0
+        ? `${e.payload.delta} advantage dot(s) will be removed`
+        : `${Math.abs(e.payload.delta)} advantage dot(s) will be restored`,
     record: (state, input) => {
       const counter = "advantagePoints";
       const priorValue = state[counter];
@@ -232,7 +236,9 @@ const handlers = {
     // reflects the state just before that purchase).
     undo: (state, entry) => {
       if (!ADVANTAGE_FLAW_COUNTERS.has(entry.payload.counter)) return;
-      state[entry.payload.counter] -= entry.payload.delta;
+      const delta = Number(entry.payload.delta);
+      if (!Number.isFinite(delta)) return;
+      state[entry.payload.counter] -= delta;
       state.spent_xp = entry.payload.priorSpentXp;
     },
   },
@@ -242,6 +248,10 @@ const handlers = {
       e.payload.delta > 0
         ? `Added ${e.payload.delta} flaw point(s)`
         : `Removed ${Math.abs(e.payload.delta)} flaw point(s)`,
+    undoEffect: (e) =>
+      e.payload.delta > 0
+        ? `${e.payload.delta} flaw dot(s) will be removed`
+        : `${Math.abs(e.payload.delta)} flaw dot(s) will be restored`,
     record: (state, input) => {
       const counter = "flaws_remaining";
       const priorValue = state[counter];
@@ -258,7 +268,9 @@ const handlers = {
     },
     undo: (state, entry) => {
       if (!ADVANTAGE_FLAW_COUNTERS.has(entry.payload.counter)) return;
-      state[entry.payload.counter] -= entry.payload.delta;
+      const delta = Number(entry.payload.delta);
+      if (!Number.isFinite(delta)) return;
+      state[entry.payload.counter] -= delta;
       state.spent_xp = entry.payload.priorSpentXp;
     },
   },

--- a/src/lib/xp/xpLog.js
+++ b/src/lib/xp/xpLog.js
@@ -16,6 +16,21 @@ export function appendEntry(log, partial, currentXp) {
   return [...log, entry];
 }
 
+// Structural validity gate for `onUndo` callers.  A corrupted entry (hostile
+// or hand-edited xp_log) must not be partially undone — refunding cost while
+// skipping the counter, or vice versa, leaves character state inconsistent.
+// Callers should check this BEFORE popping the log, refunding XP, or invoking
+// the type handler.
+const DELTA_BEARING_TYPES = new Set(["advantage", "flaw"]);
+export function isValidEntry(entry) {
+  if (!entry || typeof entry !== "object") return false;
+  if (!Number.isFinite(entry.cost)) return false;
+  if (DELTA_BEARING_TYPES.has(entry.type)) {
+    if (!Number.isFinite(Number(entry.payload?.delta))) return false;
+  }
+  return true;
+}
+
 export function undoLast(log) {
   if (log.length === 0) {
     return { log: [], entry: null };


### PR DESCRIPTION
## Summary

- **Bug 1 (HIGH)**: `advantage.undo` and `flaw.undo` in all three game-line handlers (VtM / Werewolf / Hunter) assigned `priorValue` directly, so when two entries in one Spend-XP dialog session shared a stale `priorValue` (the VtM dialog never mutated `advantages_remaining` between record calls), undoing the top entry yanked the character's counter back past where it should have landed. Switched to `state[counter] -= entry.payload.delta` so undo is self-contained per entry and robust against pre-existing log entries.
- **Bug 2 (LOW)**: "Cost to Purchase: NaN" in the Spend XP dialog between category and sub-selection. Added a `displayCost()` wrapper in all three dialogs that renders `—` when the cost isn't a finite number.
- **Secondary**: VtM dialog now mutates `this.advantages_remaining` after `record()` so future entries get an accurate `priorValue`. Werewolf and Hunter dialogs already updated their counters between calls and were not touched.

## Test plan

- [x] 6 new unit tests across `vtm.test.js`, `werewolf.test.js`, `hunter.test.js` reproduce the multi-record stale-priorValue scenario and pin the per-entry delta-undo behavior. All 60 tests pass (`npm run test:unit`).
- [x] `npm run lint` clean.
- [x] **VtM** end-to-end (char 103, baseline 47 XP / 8 Adv): buy Advantage +2 then +3 → 32 XP / 13 Adv; undo top → **41 XP / 10 Adv** (correctly −3, not −5).
- [x] **Werewolf** end-to-end (test char on 60 XP / 0 Adv): 60 → 45 / 5 → **54 / 2** after undo.
- [x] **Hunter** end-to-end (test char on 60 XP / 7 Adv): 60 → 45 / 12 → **54 / 9** after undo.
- [x] "Cost to Purchase: —" confirmed in all three Spend XP dialogs after picking Attributes without a sub-attribute.

## Notes

- Pre-fix VtM log entries on existing characters carry a stale `priorValue`. The new delta-based undo is independent of `priorValue`, so those entries will now undo correctly.
- Bug 3 (`adsbygoogle.push` on route change) was out of scope per the original triage.
- No schema changes; no server-side changes; no migration.