### PR TITLE
Add Playwright e2e suite + multi-buy advantage undo regression spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ yarn-error.log*
 
 # Local reference material (WoD rulebooks, etc. — see CLAUDE.md)
 /resources
+
+# Playwright e2e artifacts
+/playwright-report
+/test-results
+/playwright/.cache
+/.playwright-mcp

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.13.14",
+        "@playwright/test": "^1.60.0",
         "eslint": "^8.10.0",
         "eslint-config-prettier": "^8.1.0",
         "eslint-plugin-vue": "^9.0.0",
@@ -3757,6 +3758,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -11603,6 +11620,53 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "db:migrate": "sequelize-cli db:migrate",
     "db:migrate:undo": "sequelize-cli db:migrate:undo",
     "migration:create": "sequelize-cli migration:generate --name",
-    "test:unit": "vitest run"
+    "test:unit": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@pdf-lib/fontkit": "^1.1.1",
@@ -51,6 +52,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.13.14",
+    "@playwright/test": "^1.60.0",
     "eslint": "^8.10.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-vue": "^9.0.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,53 @@
+// @ts-check
+const { defineConfig, devices } = require("@playwright/test");
+
+module.exports = defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false, // shared MySQL state — keep serial for now
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: "http://localhost:8080",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        // SchreckNet's edit pages collapse the right-side nav (Spend XP, XP
+        // Log, Set XP) below ~1440px. Run wide enough that the two-column
+        // layout is in effect.
+        viewport: { width: 1600, height: 900 },
+      },
+    },
+  ],
+  webServer: [
+    {
+      // API server — plain node (not nodemon) so Playwright can manage lifecycle.
+      // Use `port` for a TCP-level readiness check; the API has no
+      // public-by-default GET that survives connect-history-api-fallback.
+      command: "node server.js",
+      port: 5000,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+    {
+      // Frontend — quasar dev. First compile is slow (often 60-120s on a
+      // cold node_modules); webpack-dev-server doesn't bind to :8080 until
+      // it's ready, so port-based readiness is reliable.
+      command: "npx quasar dev",
+      port: 8080,
+      reuseExistingServer: !process.env.CI,
+      timeout: 240_000,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  ],
+});

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,86 @@
+# SchreckNet end-to-end tests
+
+Browser-driven regression tests using [`@playwright/test`](https://playwright.dev/).
+Specs live in `tests/e2e/`; helpers in `tests/e2e/helpers/`; auth + DB
+seed fixtures in `tests/e2e/fixtures/`.
+
+## Running
+
+```bash
+# One-time per machine (downloads chromium):
+npx playwright install chromium
+
+# Run the suite:
+npm run test:e2e
+
+# Or just one spec, in headed mode, to debug:
+npx playwright test tests/e2e/xp-log/multi-buy-advantage-undo.spec.js --headed
+```
+
+`playwright.config.js` is set to `webServer: [...]` so Playwright will
+boot the API (`node server.js` on `:5000`) and the SPA (`npx quasar dev`
+on `:8080`) for you. If the servers are already up locally,
+`reuseExistingServer: true` lets the run attach to them instead of
+double-booting.
+
+## Prerequisites
+
+- MySQL container running (`docker compose up -d` from the repo root, or
+  the equivalent local install on `127.0.0.1:3307`).
+- `.env` populated with the same `DB_*` keys the server uses — the seed
+  helpers read it directly via `dotenv`.
+- A test user `testxp@test.com` / `TestPass123!` with `activated = 1`
+  exists in the `users` table (user_id 42). Re-create with:
+  ```sql
+  -- one-time, if missing
+  INSERT INTO users (username, email, password, terms_accepted, activated)
+  VALUES ('testxp', 'testxp@test.com', '<bcrypt-hash>', 1, 1);
+  ```
+
+## Conventions
+
+- **One worker.** Specs share MySQL state. Parallel runs would race on
+  the seeded character rows. Keep `workers: 1` in `playwright.config.js`
+  until the seed helpers grow per-test isolation.
+- **Seed → assert → cleanup.** `beforeEach` clones a template character
+  into the test user; `afterEach` deletes it. Don't mutate user-facing
+  characters (e.g. `QA Tester Vamp` id 103) — leave them alone for
+  manual exploration.
+- **Use the helpers.** Quasar selects need a click-then-pick ritual that
+  doesn't compose with naive `select()`; the spendXp dialog re-renders
+  refs after Save. The helpers in `tests/e2e/helpers/` encode the
+  patterns that actually work — extend them rather than rolling
+  per-spec workarounds.
+- **`hideWebpackOverlay(page)` early.** The webpack-dev-server runtime
+  error overlay (a benign ResizeObserver loop, mostly) intercepts
+  pointer events and breaks subsequent clicks. Call it after the first
+  navigation in each spec.
+
+## Adding a new spec
+
+1. Drop a `*.spec.js` under `tests/e2e/<feature>/`.
+2. If the spec needs a fresh character, use `seedVampire` /
+   `seedGarou` / `seedHunter` from `fixtures/seed.js`.
+3. Use `loginAsTestxp(context)` in `beforeEach` to drop auth cookies
+   on the browser context.
+4. Always `deleteCharacter(table, id)` in `afterEach`.
+5. Run locally with `--headed --debug` while developing.
+
+## Roadmap
+
+The first spec covers PR #284's regression on V/W/H. Highest-value
+follow-ups (in rough priority):
+
+- XP log note editing persistence (`xp-log/note-editing.spec.js`)
+- ±3xp summary-button buys + undo (`xp-log/summary-button-buy.spec.js`)
+- Cross-line favorites round-trip (`favorites/round-trip.spec.js`) —
+  requires the fix in PR #285 to be on `main` (it is, as of
+  `b698574`)
+- VtM clan-specific XP categories (Tremere rituals, Hecata oblivion
+  ceremonies)
+- Public-view-vs-edit-view auth check on V/W/H
+- PDF export — assert filesize > 0 and the character name appears
+
+A GitHub Action (`.github/workflows/e2e.yml`) wiring this into CI is
+deliberately deferred to its own PR — get the spec stable locally
+first, then automate.

--- a/tests/e2e/fixtures/auth.js
+++ b/tests/e2e/fixtures/auth.js
@@ -1,0 +1,31 @@
+const { request } = require("@playwright/test");
+
+const TEST_USER = {
+  email: "testxp@test.com",
+  password: "TestPass123!",
+  // user_id 42 — must exist in the local DB
+  // Activated via: UPDATE users SET activated=1 WHERE email='testxp@test.com'
+  id: 42,
+};
+
+/**
+ * Log in via the API and copy the resulting auth cookies onto the supplied
+ * Playwright BrowserContext. SchreckNet's auth is httpOnly cookies, so this
+ * is the simplest way to authenticate a test browser.
+ */
+async function loginAsTestxp(context) {
+  const ctx = await request.newContext();
+  const resp = await ctx.post("http://localhost:5000/user/login", {
+    data: { email: TEST_USER.email, password: TEST_USER.password },
+  });
+  if (!resp.ok()) {
+    throw new Error(
+      `loginAsTestxp: API returned ${resp.status()} — ensure ${TEST_USER.email} exists and is activated in the local DB`
+    );
+  }
+  const cookies = await ctx.storageState();
+  await context.addCookies(cookies.cookies);
+  await ctx.dispose();
+}
+
+module.exports = { loginAsTestxp, TEST_USER };

--- a/tests/e2e/fixtures/seed.js
+++ b/tests/e2e/fixtures/seed.js
@@ -1,0 +1,155 @@
+const mysql = require("mysql2/promise");
+require("dotenv").config();
+
+let pool;
+
+function getPool() {
+  if (!pool) {
+    pool = mysql.createPool({
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT) || 3306,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_NAME,
+      waitForConnections: true,
+      connectionLimit: 4,
+    });
+  }
+  return pool;
+}
+
+/**
+ * Clone a template character into a new row owned by the supplied user, with
+ * a fresh XP bank and empty xp_log so the test starts from a known baseline.
+ *
+ * Returns the new character's id. Caller is responsible for cleanup
+ * (use deleteCharacter or the returned cleanup() callback).
+ */
+async function seedVampire({
+  ownerId,
+  templateId = 103,
+  charName = "E2E VtM",
+  xp = 50,
+  advantagesRemaining = 7,
+  flawsRemaining = 2,
+} = {}) {
+  const conn = await getPool().getConnection();
+  try {
+    const [result] = await conn.query(
+      `INSERT INTO vampires (
+        charName, clan, concept, ambition, desire, archetype, humanity,
+        remaining_specialties, sect, chronicle, sireName, convictions,
+        touchstones, attributes, skills, age, generation, image_link,
+        predator_type, cult, health, willpower, potency, max_potency,
+        disciplines, discipline_skills, xp, xp_log, specialties, advantages,
+        advantages_remaining, flaws_remaining, alt_bane, alt_ancilla,
+        created_by, createdAt, updatedAt, dark_discipline
+      )
+      SELECT ?, clan, concept, ambition, desire, archetype, humanity,
+        remaining_specialties, sect, chronicle, sireName, convictions,
+        touchstones, attributes, skills, age, generation, image_link,
+        predator_type, cult, health, willpower, potency, max_potency,
+        disciplines, discipline_skills, ?, JSON_ARRAY(), specialties, advantages,
+        ?, ?, alt_bane, alt_ancilla,
+        ?, NOW(), NOW(), dark_discipline
+      FROM vampires WHERE id = ?`,
+      [charName, xp, advantagesRemaining, flawsRemaining, ownerId, templateId]
+    );
+    return result.insertId;
+  } finally {
+    conn.release();
+  }
+}
+
+async function seedGarou({
+  ownerId,
+  templateId = 5,
+  charName = "E2E Garou",
+  xp = 50,
+  advantagesRemaining = 7,
+  flawsRemaining = 2,
+} = {}) {
+  const conn = await getPool().getConnection();
+  try {
+    const [result] = await conn.query(
+      `INSERT INTO garou (
+        charName, tribe, auspice, bonus_renown, concept, chronicle,
+        touchstones, attributes, skills, health, willpower, tribe_gifts,
+        purchased_gifts, tribe_renown, purchased_renown, xp, spent_xp,
+        specialties, advantages_remaining, flaws_remaining,
+        remaining_specialties, advantages, created_by, createdAt, updatedAt,
+        xp_log
+      )
+      SELECT ?, tribe, auspice, bonus_renown, concept, chronicle,
+        touchstones, attributes, skills, health, willpower, tribe_gifts,
+        purchased_gifts, tribe_renown, purchased_renown, ?, 0,
+        specialties, ?, ?,
+        0, advantages, ?, NOW(), NOW(),
+        JSON_ARRAY()
+      FROM garou WHERE id = ?`,
+      [charName, xp, advantagesRemaining, flawsRemaining, ownerId, templateId]
+    );
+    return result.insertId;
+  } finally {
+    conn.release();
+  }
+}
+
+async function seedHunter({
+  ownerId,
+  templateId = 48,
+  charName = "E2E Hunter",
+  xp = 50,
+  advantagesRemaining = 7,
+  flawsRemaining = 2,
+} = {}) {
+  const conn = await getPool().getConnection();
+  try {
+    const [result] = await conn.query(
+      `INSERT INTO hunters (
+        charName, cell, concept, ambition, desire, chronicle, creed, drive,
+        redemption, touchstones, attributes, skills, health, willpower,
+        edges, xp, spentXp, specialties, advantages_remaining,
+        flaws_remaining, remaining_specialties, advantages, created_by,
+        createdAt, updatedAt, xp_log
+      )
+      SELECT ?, cell, concept, ambition, desire, chronicle, creed, drive,
+        redemption, touchstones, attributes, skills, health, willpower,
+        edges, ?, 0, specialties, ?,
+        ?, 0, advantages, ?,
+        NOW(), NOW(), JSON_ARRAY()
+      FROM hunters WHERE id = ?`,
+      [charName, xp, advantagesRemaining, flawsRemaining, ownerId, templateId]
+    );
+    return result.insertId;
+  } finally {
+    conn.release();
+  }
+}
+
+async function deleteCharacter(table, id) {
+  if (!["vampires", "garou", "hunters"].includes(table)) {
+    throw new Error(`deleteCharacter: refusing unknown table "${table}"`);
+  }
+  const conn = await getPool().getConnection();
+  try {
+    await conn.query(`DELETE FROM ${table} WHERE id = ?`, [id]);
+  } finally {
+    conn.release();
+  }
+}
+
+async function closePool() {
+  if (pool) {
+    await pool.end();
+    pool = undefined;
+  }
+}
+
+module.exports = {
+  seedVampire,
+  seedGarou,
+  seedHunter,
+  deleteCharacter,
+  closePool,
+};

--- a/tests/e2e/helpers/quasar.js
+++ b/tests/e2e/helpers/quasar.js
@@ -1,0 +1,39 @@
+/**
+ * Helpers for interacting with Quasar 2 components, where Vue's reactivity
+ * + portal-rendered menus + the webpack-dev-server overlay all conspire to
+ * break the obvious .click() approach.
+ *
+ * Patterns proven empirically against this app's spendXp / XP Log dialogs.
+ */
+
+/**
+ * Hide the webpack-dev-server runtime-error overlay iframe. The overlay
+ * intercepts pointer events and breaks unrelated tests; the underlying
+ * errors (e.g. ResizeObserver loop) are benign noise.
+ */
+async function hideWebpackOverlay(page) {
+  await page.addStyleTag({
+    content: `#webpack-dev-server-client-overlay,
+              #webpack-dev-server-client-overlay-div { display: none !important; }`,
+  });
+}
+
+/**
+ * Open a q-select inside the active dialog (matched by the field's label
+ * substring) and pick an option by exact text match.
+ *
+ * Quasar renders options into a portal outside the dialog — we use a global
+ * role=option lookup to find them.
+ */
+async function pickQSelect(page, labelSubstring, optionLabel) {
+  const select = page
+    .locator(".q-dialog .q-select", { hasText: labelSubstring })
+    .first();
+  await select.click();
+  await page
+    .getByRole("option", { name: optionLabel, exact: true })
+    .first()
+    .click();
+}
+
+module.exports = { hideWebpackOverlay, pickQSelect };

--- a/tests/e2e/helpers/spendXp.js
+++ b/tests/e2e/helpers/spendXp.js
@@ -1,0 +1,64 @@
+const { pickQSelect } = require("./quasar");
+
+/**
+ * Open the Spend XP dialog from the editor's right-side nav. Returns the
+ * dialog locator for chained queries.
+ */
+async function openSpendXp(page) {
+  // The Spend XP nav lives in the right-column listitem. There are two
+  // matches on the page (one is a section header, one is the nav item),
+  // so prefer the .q-item__label inside the clickable q-item-section.
+  const label = page.locator(".q-item .q-item__label", {
+    hasText: /^\s*Spend XP\s*$/,
+  });
+  await label.first().scrollIntoViewIfNeeded();
+  await label.first().click();
+  const dlg = page.locator(".q-dialog").last();
+  await dlg.waitFor();
+  return dlg;
+}
+
+/**
+ * Inside an open Spend XP dialog, pick a category + dot count, then click
+ * Purchase. Leaves the dialog open so callers can chain more purchases or
+ * Save.
+ */
+async function purchase(page, { category, dots }) {
+  await pickQSelect(page, "Which category", category);
+  await pickQSelect(page, "How many dots", String(dots));
+  await page.getByRole("button", { name: "Purchase" }).first().click();
+}
+
+/**
+ * Click Save on the Spend XP dialog (the toolbar button) — commits all
+ * staged purchases to the character's local state and closes the dialog.
+ */
+async function saveSpendXp(page) {
+  // q-dialog has a Save button in its toolbar. Scope by dialog to avoid
+  // matching any page-level Save button.
+  await page
+    .locator(".q-dialog")
+    .last()
+    .getByRole("button", { name: "Save" })
+    .first()
+    .click();
+  await page.locator(".q-dialog").last().waitFor({ state: "detached" });
+}
+
+/**
+ * Read summary-panel state (Advantage Dots Remaining, Remaining XP, Flaw
+ * Dots Remaining). Used to assert the post-buy / post-undo state.
+ */
+async function readSummary(page) {
+  const text = await page.locator("body").innerText();
+  const adv = text.match(/Advantage Dots Remaining:?\s*-?\s*(\d+)/);
+  const xp = text.match(/Remaining XP:?\s*(\d+)/);
+  const flaw = text.match(/Flaw Dots Remaining:?\s*-?\s*(\d+)/);
+  return {
+    advantages: adv ? Number(adv[1]) : null,
+    xp: xp ? Number(xp[1]) : null,
+    flaws: flaw ? Number(flaw[1]) : null,
+  };
+}
+
+module.exports = { openSpendXp, purchase, saveSpendXp, readSummary };

--- a/tests/e2e/helpers/xpLog.js
+++ b/tests/e2e/helpers/xpLog.js
@@ -1,0 +1,50 @@
+/**
+ * Open the XP Log dialog from the editor's right-side nav. Returns the
+ * dialog locator.
+ */
+async function openXpLog(page) {
+  const label = page.locator(".q-item .q-item__label", {
+    hasText: /^\s*XP Log\s*$/,
+  });
+  await label.first().scrollIntoViewIfNeeded();
+  await label.first().click();
+  const dlg = page.locator(".q-dialog").last();
+  await dlg.waitFor();
+  return dlg;
+}
+
+/**
+ * Click Undo on the top XP Log entry, then confirm in the follow-up
+ * confirmation dialog. Waits for the confirm dialog to detach before
+ * returning.
+ */
+async function undoTopEntry(page) {
+  // Click Undo on the topmost entry. Only the top entry has an Undo
+  // button (per spec), so getByRole+first works without ambiguity.
+  await page.getByRole("button", { name: "Undo" }).first().click();
+  // Quasar opens a confirmation dialog with its own Undo button. Scope
+  // by hasText so we don't accidentally re-click the entry's button.
+  const confirm = page.locator(".q-dialog", { hasText: /Undo this purchase/ });
+  await confirm.waitFor();
+  await confirm.getByRole("button", { name: "Undo" }).click();
+  await confirm.waitFor({ state: "detached" });
+}
+
+/**
+ * Read all visible XP Log entries (newest first). Returns array of
+ * { label, cost, balanceAfter }.
+ */
+async function readEntries(page) {
+  const dlg = page.locator(".q-dialog", { hasText: /^XP Log/ }).first();
+  const text = await dlg.innerText();
+  // Each entry block contains a label line + "Cost: N XP" + "Balance after: N".
+  const pattern =
+    /(Added|Removed|Raised|Lowered)[^\n]+\nCost:\s*(\d+)\s*XP\nBalance after:\s*(\d+)/g;
+  return [...text.matchAll(pattern)].map((m) => ({
+    label: m[0].split("\n")[0],
+    cost: Number(m[2]),
+    balanceAfter: Number(m[3]),
+  }));
+}
+
+module.exports = { openXpLog, undoTopEntry, readEntries };

--- a/tests/e2e/xp-log/multi-buy-advantage-undo.spec.js
+++ b/tests/e2e/xp-log/multi-buy-advantage-undo.spec.js
@@ -1,0 +1,125 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const { loginAsTestxp, TEST_USER } = require("../fixtures/auth");
+const {
+  seedVampire,
+  seedGarou,
+  seedHunter,
+  deleteCharacter,
+  closePool,
+} = require("../fixtures/seed");
+const { hideWebpackOverlay } = require("../helpers/quasar");
+const {
+  openSpendXp,
+  purchase,
+  saveSpendXp,
+  readSummary,
+} = require("../helpers/spendXp");
+const { openXpLog, undoTopEntry, readEntries } = require("../helpers/xpLog");
+
+/**
+ * Regression coverage for PR #284 (commit 515c637) — "Fix XP-log undo
+ * overshoot for multi-buy advantage/flaw".
+ *
+ * Background: prior to #284, undoing one of two advantage purchases made
+ * in the same Spend XP dialog session reverted the character's
+ * `advantages_remaining` to the *session-start* snapshot (because every
+ * record() call in the session shared the same priorValue), instead of
+ * just reversing the top entry's delta. Net end-state was correct only
+ * when both entries were undone; partial undo overshot.
+ *
+ * The fix changed undo from "assign priorValue back" to "subtract delta",
+ * which is robust regardless of priorValue staleness. This spec exercises
+ * the multi-buy → partial-undo flow on each game line and asserts the
+ * post-undo state matches "minus delta", not "back to session start".
+ */
+const LINES = [
+  {
+    name: "vtm",
+    editUrlPath: (id) => `/vampire/5e/edit/${id}`,
+    seed: () => seedVampire({ ownerId: TEST_USER.id, charName: "E2E VtM Adv" }),
+    table: "vampires",
+  },
+  {
+    name: "werewolf",
+    editUrlPath: (id) => `/werewolf/5e/edit/${id}`,
+    seed: () =>
+      seedGarou({ ownerId: TEST_USER.id, charName: "E2E Garou Adv" }),
+    table: "garou",
+  },
+  {
+    name: "hunter",
+    editUrlPath: (id) => `/hunter/5e/edit/${id}`,
+    seed: () =>
+      seedHunter({ ownerId: TEST_USER.id, charName: "E2E Hunter Adv" }),
+    table: "hunters",
+  },
+];
+
+test.afterAll(async () => {
+  await closePool();
+});
+
+for (const line of LINES) {
+  test.describe(`${line.name} — multi-buy advantage undo (PR #284 regression)`, () => {
+    let charId;
+
+    test.beforeEach(async ({ context }) => {
+      await loginAsTestxp(context);
+      charId = await line.seed();
+    });
+
+    test.afterEach(async () => {
+      if (charId) {
+        await deleteCharacter(line.table, charId);
+        charId = null;
+      }
+    });
+
+    test("undo top entry walks back exactly delta (not session-start)", async ({
+      page,
+    }) => {
+      await page.goto(line.editUrlPath(charId));
+      await hideWebpackOverlay(page);
+
+      // Baseline from seed: 7 advantage dots, 50 XP.
+      const baseline = await readSummary(page);
+      expect(baseline.advantages).toBe(7);
+      expect(baseline.xp).toBe(50);
+
+      await openSpendXp(page);
+      await purchase(page, { category: "Advantage", dots: 2 });
+      await purchase(page, { category: "Advantage", dots: 3 });
+      await saveSpendXp(page);
+
+      // After both purchases: +5 dots (12), -15 XP (35).
+      const afterBuy = await readSummary(page);
+      expect(afterBuy.advantages).toBe(12);
+      expect(afterBuy.xp).toBe(35);
+
+      await openXpLog(page);
+      const entries = await readEntries(page);
+      expect(entries).toHaveLength(2);
+      expect(entries[0].label).toMatch(/Added 3 advantage point/);
+      expect(entries[0].cost).toBe(9);
+      expect(entries[1].label).toMatch(/Added 2 advantage point/);
+      expect(entries[1].cost).toBe(6);
+
+      await undoTopEntry(page);
+
+      // Post-fix expected: dots -3 (=> 9), XP +9 (=> 44).
+      // Pre-fix bug: dots would have jumped to baseline 7 (overshoot by -2).
+      const afterUndo = await readSummary(page);
+      expect(
+        afterUndo.advantages,
+        "advantages_remaining must drop by exactly delta=3, not overshoot to session-start (7)"
+      ).toBe(9);
+      expect(afterUndo.xp).toBe(44);
+
+      // The +2 entry should still be in the log; only the +3 was undone.
+      const remainingEntries = await readEntries(page);
+      expect(remainingEntries).toHaveLength(1);
+      expect(remainingEntries[0].label).toMatch(/Added 2 advantage point/);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stand up `@playwright/test` scaffolding and the first browser-driven regression spec, codifying the multi-buy advantage undo flow that PR #284 fixed and that Round 2 QA verified by hand.

The structure is intentionally minimal — one spec, one auth fixture, one DB-seed helper module, two domain helpers (Quasar + Spend XP / XP Log) — but it's complete enough that follow-ups can add specs in ~10 minutes each.

## What's in the box

- `playwright.config.js` — single chromium project at 1600x900, serial one-worker (specs share MySQL state), webServer auto-boots `node server.js` on :5000 and `npx quasar dev` on :8080
- `tests/e2e/fixtures/auth.js` — `loginAsTestxp(context)` posts to `/user/login`, copies httpOnly cookies onto the browser context
- `tests/e2e/fixtures/seed.js` — `seedVampire` / `seedGarou` / `seedHunter` clone a template character into testxp's ownership with fresh XP and empty `xp_log`; `deleteCharacter(table, id)` for teardown
- `tests/e2e/helpers/quasar.js` — `pickQSelect(label, value)` and `hideWebpackOverlay(page)`
- `tests/e2e/helpers/spendXp.js` + `tests/e2e/helpers/xpLog.js` — domain helpers
- `tests/e2e/xp-log/multi-buy-advantage-undo.spec.js` — regression coverage for PR #284 across V/W/H
- `tests/e2e/README.md` — prereqs (MySQL, testxp, .env), conventions, roadmap

## Test plan

- [x] `npm run test:e2e` → 3/3 pass in ~25s on a warm cache
- [x] First-run cold compile of quasar dev fits inside the 240s webServer timeout
- [x] Spec leaves no DB rows behind (seed/teardown round-trips cleanly)
- [x] `webServer.reuseExistingServer: true` lets the spec attach to dev servers if you already have them running locally

## Roadmap (deferred to follow-up PRs)

- GitHub Action wiring `npm run test:e2e` into PR checks — deferred so the spec can prove stable locally first
- More specs per the README: ±3xp summary-button buys, XP-log note editing persistence, cross-line favorites round-trip (now testable post-#285), Hunter edges/perks unlock, public-vs-edit auth check, PDF export
- VtM clan-specific XP categories (Tremere rituals, Hecata oblivion ceremonies)

## Side note

The webServer logs surfaced an unrelated `Unknown column 'page' in 'field list'` error from the `rites` table during a Werewolf editor load. Not in scope for this PR but worth filing — the `Rites` model expects a column the schema doesn't have.