### PR TITLE
Fix R2 Defects 3 + 5: stop spurious adsbygoogle pushes; align gift models with schema

### DIFF
--- a/server/models/werewolf/AuspiceGifts.js
+++ b/server/models/werewolf/AuspiceGifts.js
@@ -37,14 +37,6 @@ const AuspiceGifts = db.sequelize.define(
       type: Sequelize.INTEGER,
       allowNull: false,
     },
-    page: {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-    },
-    short_desc: {
-      type: Sequelize.STRING,
-      allowNull: false,
-    },
   },
   { timestamps: false }
 );

--- a/server/models/werewolf/NativeGifts.js
+++ b/server/models/werewolf/NativeGifts.js
@@ -31,14 +31,6 @@ const NativeGifts = db.sequelize.define(
       type: Sequelize.INTEGER,
       allowNull: false,
     },
-    page: {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-    },
-    short_desc: {
-      type: Sequelize.STRING,
-      allowNull: false,
-    },
   },
   { timestamps: false }
 );

--- a/server/models/werewolf/TribeGifts.js
+++ b/server/models/werewolf/TribeGifts.js
@@ -37,14 +37,6 @@ const TribeGifts = db.sequelize.define(
       type: Sequelize.INTEGER,
       allowNull: false,
     },
-    page: {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-    },
-    short_desc: {
-      type: Sequelize.STRING,
-      allowNull: false,
-    },
   },
   { timestamps: false }
 );

--- a/src/components/homePage.vue
+++ b/src/components/homePage.vue
@@ -97,12 +97,6 @@ export default {
   },
   async mounted() {
     try {
-      (window.adsbygoogle = window.adsbygoogle || []).push({});
-    } catch (e) {
-      console.error("AdSense error:", e);
-    }
-
-    try {
       const resp = await this.$api.get("/user/currentUser", {
         withCredentials: true,
       });

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -241,13 +241,5 @@ export default defineComponent({
         return resp.data;
       });
   },
-
-  watch: {
-    $route() {
-      if (window.adsbygoogle) {
-        window.adsbygoogle.push({});
-      }
-    },
-  },
 });
 </script>


### PR DESCRIPTION
## Summary

Closes out the two remaining R2 defects from `docs/qa/reports/2026-05-15-xp-log.md` §7. Two unrelated bugs grouped because both are small and were filed as siblings; squash if you'd rather land them separately.

### Defect 3 — `adsbygoogle.push` on every route change

`adsbygoogle.push({})` is a one-time-per-`<ins>` registration, not a refresh. Two stray call sites were firing it on every nav (`MainLayout.vue` `$route` watcher) and every homePage mount (`homePage.vue` mounted hook), which threw `TagError: All 'ins' elements... already have ads in them` into the console after the first mount.

In-page ads come from Google Auto Ads via the `google-adsense-account` meta tag in `src/index.template.html` — they self-initialize. The dedicated `AdSense.vue` component (the proper push site) isn't imported anywhere right now. Removing the two redundant pushes silences the console errors without losing any actual ad behaviour.

### Defect 5 — gift endpoints 404 because models declare missing columns

`NativeGifts`, `AuspiceGifts`, `TribeGifts` each declared `page` (INT NOT NULL) and `short_desc` (STRING NOT NULL). Tables don't have them; Sequelize threw `Unknown column 'page' in 'field list'`; route catch blocks returned 404. Werewolf editor's gift dropdowns + Spend XP gift purchases were silently broken in dev.

Nothing in the frontend reads `page` or `short_desc` (verified by grep across `src/components/character_creator/werewolf/`), so removing the fields is safe and brings model and schema into alignment. Verified empirically with the API back up:

```
GET /garou/native_gifts/3    → 200, 7+ gifts
GET /garou/auspice_gifts/3/5 → 200, gifts for that auspice
GET /garou/tribe_gifts/3/7   → 200, gifts for that tribe
```

The matching `Rites` model has the same shape and is intentionally untouched here — issue #287 tracks it separately so it can resolve via a migration that preserves the planned rule data.

## Test plan

- [x] `npm run test:unit` — 79/79 pass
- [x] `npm run test:e2e` — 3/3 pass on V/W/H multi-buy advantage undo
- [x] Empirical curl probes of the three gift endpoints return 200 with gift JSON

## Out of scope

- Issue #287 (`rites` model has the same `page`/`short_desc` mismatch). Suggested fix there is to add a migration that creates the columns — keeping that decision in its own PR.
- The `connect-history-api-fallback` middleware is in front of the API routes in `server.js`, which means `curl` without an explicit `Accept: application/json` header gets rewritten to `/index.html` and 404s. Annoying for direct probing but doesn't affect the SPA (axios sends `Accept: application/json, text/plain, */*` and... actually that *does* trigger the fallback in some configs — worth a follow-up look but out of scope here).